### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
   "devDependencies": {
     "gulp-util": "^3.0.3",
     "through2": "^0.6.3"
+  },
+  "dependencies": {
+    "gulp-util": "^3.0.3",
+    "through2": "^0.6.3"
   }
 }


### PR DESCRIPTION
在外部程序npm install 的情况下，gulp-coimport 不会下载through2包。在package中增加了依赖。
module.js:338
    throw err;
          ^
Error: Cannot find module 'through2'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/var/code/Public/Static/node_modules/gulp-coimport/src/gulp-coimport.js:1:77)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
